### PR TITLE
Explainer updates for clarity, grammar, and URL localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Another possible simplification is to make the `capabilities()` APIs synchronous
 
 ### Allowing unknown source languages for translation
 
-An earlier version of this API included support for combining the langauge detection and translation steps into a single translation call, with a best-guess on the source language. The idea implied that this could possibly be more efficient than requiring two separate calls, and that it could possibly even be done using a single model.
+An earlier version of this API included support for combining the langauge detection and translation steps into a single translation call, with a best-guess on the source language. The idea implied that this approach may be more efficient than requiring two separate calls, and that translation could possibly be done using a single model.
 
 We abandoned this design when it became clear that existing browsers have very decoupled implementations of translation vs. language detection, using separate models for each. This includes supporting different languages for language detection vs. for translation. So even if the translation model supported an unknown-source-language mode, it might not support the same inputs as the language detection model, which would create a confusing developer experience and be hard to signal in the capabilities API.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An important supplement to translation is language detection. This can be combin
 
 Our goals are to:
 
-* Help web developers perform real-time translations (for example, of user input).
+* Help web developers perform real-time translations (e.g., of user input).
 * Help web developers perform real-time language detection.
 * Guide web developers to gracefully handle failure cases, e.g. translation not being available or possible.
 * Harmonize well with existing browser and OS translation technology ([Brave](https://support.brave.com/hc/articles/8963107404813-How-do-I-use-Brave-Translate), [Chrome](https://support.google.com/chrome/answer/173424&co=GENIE.Platform%3DDesktop#zippy=%2Ctranslate-selected-text), [Edge](https://support.microsoft.com/topic/use-microsoft-translator-in-microsoft-edge-browser-4ad1c6cb-01a4-4227-be9d-a81e127fcb0b), [Firefox](https://support.mozilla.org/kb/website-translation), [Safari](https://9to5mac.com/2020/12/04/how-to-translate-websites-with-safari-mac/)), e.g. by allowing on-the-fly downloading of different languages instead of assuming all are present from the start.
@@ -26,12 +26,12 @@ Our goals are to:
 
 The following are explicit non-goals:
 
-* We don't intend to force every browser to ship language packs for every language combination, or even to support translation at all. It would be conforming to implement this API by always saying translation and language detection are unavailable, or to implement this API entirely by using cloud services instead of on-device translation.
-* We don't intend to provide guarantees of translation and language detection quality, stability, or interoperability between browsers. These are left as quality-of-implementation issues, similar to the [shape detection API](https://wicg.github.io/shape-detection-api/). (See also a [discussion of interop](https://www.w3.org/reports/ai-web-impact/#interop) in the W3C "AI & the Web" document.)
+* We do not intend to force every browser to ship language packs for every language combination, or even to support translation at all. It would be conforming to implement this API by always saying translation and language detection are unavailable, or to implement this API entirely by using cloud services instead of on-device translation.
+* We do not intend to provide guarantees of translation and language detection quality, stability, or interoperability between browsers. These are left as quality-of-implementation issues, similar to the [shape detection API](https://wicg.github.io/shape-detection-api/). (See also a [discussion of interop](https://www.w3.org/reports/ai-web-impact/#interop) in the W3C "AI & the Web" document.)
 
 The following are potential goals we are not yet certain of:
 
-* Allow web developers to know whether translation takes place on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
+* Allow web developers to know whether translation are done on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
 * Allow web developers to know some identifier for the translation and language detection models in use, separate from the browser version. This would allow them to allowlist or blocklist specific models to maintain a desired level of quality.
 
 Both of these potential goals are potentially detrimental to interoperability, so we want to investigate more how important such functionality is to developers to find the right tradeoff.
@@ -377,7 +377,7 @@ Another possible simplification is to make the `capabilities()` APIs synchronous
 
 ### Allowing unknown source languages for translation
 
-An earlier version of this API included support for combining the langauge detection and translation steps into a single translation call, with a best-guess on the source language. The idea implied that this approach may be more efficient than requiring two separate calls, and that translation could possibly be done using a single model.
+An earlier version of this API included support for combining the langauge detection and translation steps into a single translation call, with a best-guess on the source language. The idea implied that this approach would be more efficient than requiring two separate calls, and that translation could possibly be done using a single model.
 
 We abandoned this design when it became clear that existing browsers have very decoupled implementations of translation vs. language detection, using separate models for each. This includes supporting different languages for language detection vs. for translation. So even if the translation model supported an unknown-source-language mode, it might not support the same inputs as the language detection model, which would create a confusing developer experience and be hard to signal in the capabilities API.
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Our goals are to:
 
 The following are explicit non-goals:
 
-* We do not intend to force every browser to ship language packs for every language combination, or even to support translation at all. It would be conforming to implement this API by always saying translation and language detection are unavailable, or to implement this API entirely by using cloud services instead of on-device translation.
-* We do not intend to provide guarantees of translation and language detection quality, stability, or interoperability between browsers. These are left as quality-of-implementation issues, similar to the [shape detection API](https://wicg.github.io/shape-detection-api/). (See also a [discussion of interop](https://www.w3.org/reports/ai-web-impact/#interop) in the W3C "AI & the Web" document.)
+* We don't intend to force every browser to ship language packs for every language combination, or even to support translation at all. It would be conforming to implement this API by always saying translation and language detection are unavailable, or to implement this API entirely by using cloud services instead of on-device translation.
+* We don't intend to provide guarantees of translation and language detection quality, stability, or interoperability between browsers. These are left as quality-of-implementation issues, similar to the [shape detection API](https://wicg.github.io/shape-detection-api/). (See also a [discussion of interop](https://www.w3.org/reports/ai-web-impact/#interop) in the W3C "AI & the Web" document.)
 
 The following are potential goals we are not yet certain of:
 
-* Allow web developers to know whether translations are done on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
+* Allow web developers to know whether translation takes place on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
 * Allow web developers to know some identifier for the translation and language detection models in use, separate from the browser version. This would allow them to allowlist or blocklist specific models to maintain a desired level of quality.
 
 Both of these potential goals are potentially detrimental to interoperability, so we want to investigate more how important such functionality is to developers to find the right tradeoff.
@@ -146,7 +146,7 @@ async function translateUnknownCustomerInput(textToTranslate, targetLanguage) {
 
 ### Download progress
 
-In cases where translation or language detection is only possible after a download, you can monitor the download progress (e.g. in order to show your users a progress bar) using code such as the following:
+In cases where translation or language detection is only possible after a download, you can monitor the download progress (in order to show your users a progress bar) using code such as the following:
 
 ```js
 const translator = await ai.translator.create({
@@ -331,7 +331,7 @@ This design means that the implementation must have all information about the ca
 
 This proposal as-is has privacy issues, which we are actively thinking about how to address. They are all centered around how sites that use this API might be able to uniquely fingerprint the user.
 
-The most obvious identifier in the current API design is the list of supported languages, and especially their availability status (`"no"`, `"readily"`, or `"after-download"`). For example, as of the time of this writing [Firefox supports 9 languages](https://www.mozilla.org/en-US/firefox/features/translate/), which can each be [independently downloaded](https://support.mozilla.org/en-US/kb/website-translation#w_configure-installed-languages). With a naive implementation, this gives 9 bits of identifying information, which various sites can all correlate.
+The most obvious identifier in the current API design is the list of supported languages, and especially their availability status (`"no"`, `"readily"`, or `"after-download"`). For example, as of the time of this writing [Firefox supports 9 languages](https://www.mozilla.org/firefox/features/translate/), which can each be [independently downloaded](https://support.mozilla.org/kb/website-translation#w_configure-installed-languages). With a naive implementation, this gives 9 bits of identifying information, which various sites can all correlate.
 
 Some sort of mitigation may be necessary here. We believe this is adjacent to other areas that have seen similar mitigation, such as the [Local Font Access API](https://github.com/WICG/local-font-access/blob/main/README.md). Possible techniques are:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ async function translateUnknownCustomerInput(textToTranslate, targetLanguage) {
 
 ### Download progress
 
-In cases where translation or language detection is only possible after a download, you can monitor the download progress (in order to show your users a progress bar) using code such as the following:
+In cases where translation or language detection is only possible after a download, you can monitor the download progress (e.g. in order to show your users a progress bar) using code such as the following:
 
 ```js
 const translator = await ai.translator.create({

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following are explicit non-goals:
 
 The following are potential goals we are not yet certain of:
 
-* Allow web developers to know whether translation are done on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
+* Allow web developers to know whether translation is done on-device or using cloud services. This would allow them to guarantee that any user data they feed into this API does not leave the device, which can be important for privacy purposes. (Similarly, we might want to allow developers to request on-device-only translation, in case a browser offers both varieties.)
 * Allow web developers to know some identifier for the translation and language detection models in use, separate from the browser version. This would allow them to allowlist or blocklist specific models to maintain a desired level of quality.
 
 Both of these potential goals are potentially detrimental to interoperability, so we want to investigate more how important such functionality is to developers to find the right tradeoff.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Browsers are increasingly offering language translation to their users. Such tra
 
 To perform translation in such cases, web sites currently have to either call out to cloud APIs, or bring their own translation models and run them using technologies like WebAssembly and WebGPU. This proposal introduces a new JavaScript API for exposing a browser's existing language translation abilities to web pages, so that if present, they can serve as a simpler and less resource-intensive alternative.
 
-An important supplement to translation is language detection. This can be combined with translation, e.g. taking user input in an unknown language and translating it to a specific target language. In a similar way, browsers today often already have langauge detection capabilities, and we want to offer them to web developers through a JavaScript API.
+An important supplement to translation is language detection. This can be combined with translation, e.g. taking user input in an unknown language and translating it to a specific target language. In a similar way, browsers today often already have language detection capabilities, and we want to offer them to web developers through a JavaScript API.
 
 ## Goals
 
 Our goals are to:
 
-* Help web developers perform real-time translations (e.g. of user input).
+* Help web developers perform real-time translations (for example, of user input).
 * Help web developers perform real-time language detection.
 * Guide web developers to gracefully handle failure cases, e.g. translation not being available or possible.
-* Harmonize well with existing browser and OS translation technology ([Brave](https://support.brave.com/hc/en-us/articles/8963107404813-How-do-I-use-Brave-Translate), [Chrome](https://support.google.com/chrome/answer/173424?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Ctranslate-selected-text), [Edge](https://support.microsoft.com/en-us/topic/use-microsoft-translator-in-microsoft-edge-browser-4ad1c6cb-01a4-4227-be9d-a81e127fcb0b), [Firefox](https://support.mozilla.org/en-US/kb/website-translation), [Safari](https://9to5mac.com/2020/12/04/how-to-translate-websites-with-safari-mac/)), e.g. by allowing on-the-fly downloading of different languages instead of assuming all are present from the start.
+* Harmonize well with existing browser and OS translation technology ([Brave](https://support.brave.com/hc/articles/8963107404813-How-do-I-use-Brave-Translate), [Chrome](https://support.google.com/chrome/answer/173424&co=GENIE.Platform%3DDesktop#zippy=%2Ctranslate-selected-text), [Edge](https://support.microsoft.com/topic/use-microsoft-translator-in-microsoft-edge-browser-4ad1c6cb-01a4-4227-be9d-a81e127fcb0b), [Firefox](https://support.mozilla.org/kb/website-translation), [Safari](https://9to5mac.com/2020/12/04/how-to-translate-websites-with-safari-mac/)), e.g. by allowing on-the-fly downloading of different languages instead of assuming all are present from the start.
 * Allow a variety of implementation strategies, including on-device vs. cloud-based translation, while keeping these details abstracted from developers.
 * Allow implementations to expose different capabilities for translation vs. language detection. For example, an implementation might be able to detect 30+ languages, but only be able to translate between 6.
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Another possible simplification is to make the `capabilities()` APIs synchronous
 
 ### Allowing unknown source languages for translation
 
-An earlier revision of this API including support for combining the langauge detection and translation steps into a single translation call, which did a best-guess on the source language. The idea was that this would possibly be more efficient than requiring the web developer to do two separate calls, and it could possibly even be done using a single model.
+An earlier version of this API included support for combining the langauge detection and translation steps into a single translation call, with a best-guess on the source language. The idea implied that this could possibly be more efficient than requiring two separate calls, and that it could possibly even be done using a single model.
 
 We abandoned this design when it became clear that existing browsers have very decoupled implementations of translation vs. language detection, using separate models for each. This includes supporting different languages for language detection vs. for translation. So even if the translation model supported an unknown-source-language mode, it might not support the same inputs as the language detection model, which would create a confusing developer experience and be hard to signal in the capabilities API.
 


### PR DESCRIPTION
This PR fixes a spelling error, suggests changes for clarity in certain parts of the explainer, and removes English/US-based URL structure from links so that readers are directed to a localized URL.